### PR TITLE
Fix powershell

### DIFF
--- a/after/plugin/dapui.lua
+++ b/after/plugin/dapui.lua
@@ -1,6 +1,15 @@
 local dapui = require("dapui")
 local dap = require("dap")
 dapui.setup()
-dap.listeners.after.event_initialized["dapui_config"] = function()
-    dapui.open({})
+dap.listeners.before.attach.dapui_config = function()
+  dapui.open()
+end
+dap.listeners.before.launch.dapui_config = function()
+  dapui.open()
+end
+dap.listeners.before.event_terminated.dapui_config = function()
+  dapui.close()
+end
+dap.listeners.before.event_exited.dapui_config = function()
+  dapui.close()
 end

--- a/after/plugin/dapui.lua
+++ b/after/plugin/dapui.lua
@@ -3,5 +3,4 @@ local dap = require("dap")
 dapui.setup()
 dap.listeners.after.event_initialized["dapui_config"] = function()
     dapui.open({})
-    require('dap-powershell').correct_repl_colors()
 end

--- a/after/plugin/lsp.lua
+++ b/after/plugin/lsp.lua
@@ -8,6 +8,7 @@ lsp.ensure_installed({
   'powershell_es',
   'clangd'
 })
+lsp.skip_server_setup({'powershell_es'})
 
 -- Fix Undefined global 'vim'
 lsp.nvim_workspace()
@@ -51,20 +52,6 @@ lsp.on_attach(function(client, bufnr)
   vim.keymap.set("n", "<leader>vrn", function() vim.lsp.buf.rename() end, opts)
   vim.keymap.set("i", "<C-h>", function() vim.lsp.buf.signature_help() end, opts)
 end)
-
--- PowerShell LSP config
-lsp.configure('powershell_es', {
-  bundle_path = bundle_path,
-  on_attach = on_attach,
-  settings = {
-    powershell = {
-      codeFormatting = {
-        Preset = 'OTBS'
-      }
-    }
-  }
-})
-
 
 lsp.setup()
 

--- a/after/plugin/powershell.lua
+++ b/after/plugin/powershell.lua
@@ -1,4 +1,9 @@
 require('powershell').setup({
    bundle_path = vim.fn.stdpath "data" .. "/mason/packages/powershell-editor-services",
+   settings={
+      codeFormatting = {
+         preset = 'OTBS'
+      }
+   }
 })
 

--- a/lua/f0oster/init.lua
+++ b/lua/f0oster/init.lua
@@ -1,5 +1,6 @@
 require("f0oster.set")
 require("f0oster.remap")
+require("f0oster.packer")
 
 -- DO NOT INCLUDE THIS
 vim.opt.rtp:append("~/personal/streamer-tools")

--- a/lua/f0oster/packer.lua
+++ b/lua/f0oster/packer.lua
@@ -75,23 +75,6 @@ return require("packer").startup(function(use)
 
 	--  additions for PowerShell / DAP UI
 	use({ "rcarriga/nvim-dap-ui", requires = { "mfussenegger/nvim-dap", "nvim-neotest/nvim-nio" } })
-	use("m00qek/baleia.nvim")
-
-	use({
-		"Willem-J-an/nvim-dap-powershell",
-		dependencies = {
-			"mfussenegger/nvim-dap",
-			"rcarriga/nvim-dap-ui",
-			{
-				"m00qek/baleia.nvim",
-				lazy = true,
-				tag = "v1.4.0",
-			},
-		},
-		config = function()
-			require("dap-powershell").setup()
-		end,
-	})
 
 	use({
 		"TheLeoP/powershell.nvim",


### PR DESCRIPTION
Fixes the problems stated in https://github.com/TheLeoP/powershell.nvim/issues/3

Also,
- I couldn't execute your config locally because you weren't calling `require('f0oster.packer')`, so I fix it
- I updated the listeners for dap-ui (maybe you weren't using the close listeners on purpose(?), you could delete them if that's the case)
- I removed `dap-powershell` because `powershell.nvim` already handles debugging and both configurations may clash (or your would only use one of them). `dap-powershell` does support interactive debugging (through the dap-repl), but it doesn't work on windows (because [nvim-dap does not handle named pipes nicely on Windows](https://github.com/mfussenegger/nvim-dap/issues/1230)). `powershell.nvim` works on Windows (including debugging), but it does not support interactive debugging because of [a bug with Powershell Editor Services](https://github.com/PowerShell/PowerShellEditorServices/issues/2164)